### PR TITLE
fix: TypedArray cleanup

### DIFF
--- a/android/src/main/cpp/Tflite.cpp
+++ b/android/src/main/cpp/Tflite.cpp
@@ -30,6 +30,16 @@ public:
     }
     auto jsCallInvoker = jsCallInvokerHolder->cthis()->getCallInvoker();
 
+
+    // Adds the PropNameIDCache object to the Runtime. If the Runtime gets
+    // destroyed, the Object gets destroyed and the cache gets invalidated.
+    auto propNameIdCache = std::make_shared<InvalidateCacheOnDestroy>(runtime);
+    runtime.global().setProperty(
+      runtime,
+      "tfPluginPropNameIdCache",
+      jsi::Object::createFromHostObject(runtime, propNameIdCache)
+    );
+
     auto fetchByteDataFromUrl = [](std::string url) {
       // Attaching Current Thread to JVM
       JNIEnv* env = nullptr;

--- a/spec/NativeRNTflite.ts
+++ b/spec/NativeRNTflite.ts
@@ -1,9 +1,8 @@
-
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
+import type { TurboModule } from 'react-native'
+import { TurboModuleRegistry } from 'react-native'
 
 export interface Spec extends TurboModule {
-    install(): boolean;
+  install(): boolean
 }
 
-export default TurboModuleRegistry.get<Spec>('Tflite');
+export default TurboModuleRegistry.get<Spec>('Tflite')

--- a/src/TensorflowModule.ts
+++ b/src/TensorflowModule.ts
@@ -1,1 +1,1 @@
-export { default as TensorflowModule } from '../spec/NativeRNTflite';
+export { default as TensorflowModule } from '../spec/NativeRNTflite'


### PR DESCRIPTION
* Add reference to `propNameIdCache` to JSI runtime
* Small lint changes